### PR TITLE
Improve POI fallback handling in Shiny app

### DIFF
--- a/POI_init.R
+++ b/POI_init.R
@@ -1,0 +1,99 @@
+# poi_initializer.R
+# Liest die POI_R.xlsx Datei ein und bereitet sie für die weitere Verwendung vor
+
+library(readxl)
+library(data.table)
+
+# --- Pfad zur Excel-Datei anpassen ---
+file_path <- "POI_R.xlsx"
+
+# --- Excel einlesen (nur erstes Blatt, alle Spalten als Text) ---
+poi_raw <- read_excel(file_path, col_types = "text")
+
+# --- In data.table konvertieren ---
+poi <- as.data.table(poi_raw)
+
+# --- Spalten bereinigen und typisieren ---
+setnames(poi, tolower(names(poi)))  # Spaltennamen klein
+setnames(poi, c("id", "name", "lat", "lon", "kategorie", "typ", "range"))  # zur Sicherheit
+
+# Komma in Punkt konvertieren und numerisch casten
+poi[, lat := as.numeric(gsub(",", ".", lat, fixed = TRUE))]
+poi[, lon := as.numeric(gsub(",", ".", lon, fixed = TRUE))]
+poi[, id  := as.integer(id)]
+
+# --- Ergebnis prüfen ---
+print(poi)
+
+# --- Global speichern (optional) ---
+assign("poi_table", poi, envir = .GlobalEnv)
+message("✅ POI-Tabelle erfolgreich geladen: ", nrow(poi), " Einträge")
+
+
+
+
+# track_poi_by_range.R
+# POI-Zuordnung: nur wenn innerhalb definierter Range, inkl. Match-Qualität (je näher am Zentrum, desto höher)
+
+library(data.table)
+library(geosphere)
+
+# Sicherheitsprüfung
+if (!exists("gps_index", envir = .GlobalEnv) || !exists("poi_table", envir = .GlobalEnv)) {
+  stop("❌ gps_index oder poi_table nicht gefunden.")
+}
+
+gps_index <- get("gps_index", envir = .GlobalEnv)
+poi_table <- get("poi_table", envir = .GlobalEnv)
+
+# Prüfen, ob 'range' vorhanden und numerisch ist
+if (!"range" %in% names(poi_table)) stop("❌ Spalte 'range' fehlt in poi_table")
+poi_table[, range := as.numeric(range)]
+
+# Initialisierung
+n <- nrow(gps_index)
+start_poi_ids   <- rep(NA_integer_, n)
+end_poi_ids     <- rep(NA_integer_, n)
+start_poi_score <- rep(NA_real_, n)
+end_poi_score   <- rep(NA_real_, n)
+
+# Funktion zur POI-Suche innerhalb Range + Matchscore (0–100%)
+find_matching_poi <- function(lat, lon, poi_dt) {
+  dists <- distHaversine(matrix(c(poi_dt$lon, poi_dt$lat), ncol = 2), c(lon, lat))
+  poi_dt[, dist_m := dists]
+  in_range <- poi_dt[dist_m <= range]
+  if (nrow(in_range) == 0L) return(list(id = NA_integer_, score = NA_real_))
+  
+  best <- in_range[which.min(dist_m)]
+  score <- (1 - best$dist_m / best$range) * 100
+  return(list(id = best$id, score = round(score, 1)))
+}
+
+# Schleife über alle Tracks
+for (i in seq_len(n)) {
+  start <- gps_index$start_coord[[i]]
+  end   <- gps_index$end_coord[[i]]
+  
+  if (!is.null(start) && !any(is.na(start))) {
+    res <- find_matching_poi(start$lat, start$lon, poi_table)
+    start_poi_ids[i]   <- res$id
+    start_poi_score[i] <- res$score
+  }
+  
+  if (!is.null(end) && !any(is.na(end))) {
+    res <- find_matching_poi(end$lat, end$lon, poi_table)
+    end_poi_ids[i]   <- res$id
+    end_poi_score[i] <- res$score
+  }
+}
+
+# Ergebnis speichern
+gps_index[, `:=`(
+  poi_start_id = start_poi_ids,
+  poi_end_id   = end_poi_ids,
+  poi_start_score = start_poi_score,
+  poi_end_score   = end_poi_score
+)]
+
+assign("gps_index", gps_index, envir = .GlobalEnv)
+message("✅ POI-Zuordnung abgeschlossen (nur innerhalb Range, inkl. Score).")

--- a/README.md
+++ b/README.md
@@ -150,10 +150,13 @@ Damit die Shiny-App inklusive OSRM-Routen ohne Fehlermeldungen startet, müssen 
    - Skript ausführen, um zu jeder Fahrt Distanz, Dauer und Koordinaten der optimalen Route zu ermitteln (`osrm_distance_m`, `osrm_duration_s`, `osrm_route_coords`).
 
 5. **POI-Tabelle bereitstellen**
-   - Die Shiny-App erwartet ein Objekt `poi_table` mit mindestens den Spalten `id` und `name` für Start-/Zielbezeichnungen. Lade oder erstelle diese Tabelle vor dem Start (z. B. aus einer CSV einlesen und als `data.table` speichern).
+   - Die Shiny-App erwartet ein Objekt `poi_table` mit mindestens den Spalten `id` und `name` für Start-/Zielbezeichnungen.
+   - Empfohlen: `source("POI_init.R")`, um die Datei `POI_R.xlsx` einzulesen, Spalten zu typisieren und optionale Start-/Ziel-Scores in `gps_index` zu ergänzen.
+   - Alternativ kann eine eigene Tabelle aufgebaut werden (z. B. CSV einlesen und als `data.table` speichern).
+   - Falls beim Start der Shiny-App keine `poi_table` gefunden wird, fällt die Anwendung automatisch auf eine leere Tabelle zurück und zeigt einen Warnhinweis – die App bleibt lauffähig, jedoch ohne benannte Start-/Zielorte.
 
 6. **Shiny-App starten – `gps_shiny_app_with_osrm.R`**
    - Nach erfolgreichem Abschluss der Schritte 2–5 `source("gps_shiny_app_with_osrm.R")` ausführen.
    - Die App liest `gps_index`, `gps_data` und `poi_table` aus dem `.GlobalEnv` und ermöglicht das Ein- und Ausblenden von GPS-Tracks sowie OSRM-Routen inklusive farblicher Geschwindigkeitsdarstellung.
 
-**Tipp:** Sollte eines der Objekte fehlen, brechen die Skripte bewusst mit einer Fehlermeldung ab. Das hilft, eine inkonsistente Reihenfolge schnell zu erkennen.
+**Tipp:** Sollte eines der Kernobjekte (`gps_index`, `gps_data`) fehlen, brechen die Skripte bewusst mit einer Fehlermeldung ab. Für `poi_table` wird automatisch eine leere Fallback-Tabelle erzeugt, falls keine Daten bereitstehen.

--- a/gps_shiny_app_with_osrm.R
+++ b/gps_shiny_app_with_osrm.R
@@ -104,13 +104,26 @@ ui <- fluidPage(
 server <- function(input, output, session) {
   req(exists("gps_index", envir = .GlobalEnv))
   req(exists("gps_data", envir = .GlobalEnv))
-  req(exists("poi_table", envir = .GlobalEnv))
-  
+
   gps_index <- get("gps_index", envir = .GlobalEnv)
   gps_data <- get("gps_data", envir = .GlobalEnv)
-  poi_table <- get("poi_table", envir = .GlobalEnv)
-  
-  poi_lookup <- poi_table[, .(id, name)]
+
+  poi_lookup <- data.table(id = integer(), name = character())
+  poi_warning <- NULL
+  if (exists("poi_table", envir = .GlobalEnv)) {
+    poi_table <- get("poi_table", envir = .GlobalEnv)
+    if (all(c("id", "name") %in% names(poi_table))) {
+      poi_lookup <- poi_table[, .(id, name)]
+    } else {
+      poi_warning <- "POI-Tabelle ohne 'id'/'name'-Spalten gefunden. Es wird eine leere Tabelle verwendet."
+    }
+  } else {
+    poi_warning <- "POI-Tabelle nicht gefunden. Es wird eine leere Tabelle verwendet."
+  }
+
+  if (!is.null(poi_warning)) {
+    showNotification(poi_warning, type = "warning")
+  }
   gps_index[, tag := format(start_time, "%Y-%m-%d")]
   updateSelectInput(session, "day", choices = unique(gps_index$tag), selected = unique(gps_index$tag)[1])
   
@@ -132,14 +145,17 @@ server <- function(input, output, session) {
     df[, `OSRM-Zeit` := osrm_duration_hm]
     df[, `Ist-Zeit` := real_duration_hm]
     
-    df <- merge(df, poi_lookup, by.x = "poi_start_id", by.y = "id", all.x = TRUE)
-    setnames(df, "name", "StartOrt")
-    df <- merge(df, poi_lookup, by.x = "poi_end_id", by.y = "id", all.x = TRUE)
-    setnames(df, "name", "ZielOrt")
-    
+    if (nrow(poi_lookup) > 0) {
+      df <- merge(df, poi_lookup, by.x = "poi_start_id", by.y = "id", all.x = TRUE)
+      setnames(df, "name", "StartOrt")
+      df <- merge(df, poi_lookup, by.x = "poi_end_id", by.y = "id", all.x = TRUE)
+      setnames(df, "name", "ZielOrt")
+    }
+
     setorder(df, start_time)
-    
-    
+
+    if (!"StartOrt" %in% names(df)) df[, StartOrt := NA_character_]
+    if (!"ZielOrt" %in% names(df)) df[, ZielOrt := NA_character_]
     df[is.na(StartOrt), StartOrt := "(unbekannt)"]
     df[is.na(ZielOrt), ZielOrt := "(unbekannt)"]
     


### PR DESCRIPTION
## Summary
- ensure the Shiny server validates the POI table before falling back to an empty dataset and warns the user once
- guard the POI merge logic so Start/Ziel columns remain available even without metadata
- document the POI initialization script and fallback behaviour in the README

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68dba4e7514883309939eb43a92d56d3