### PR TITLE
Add frequency selection and downsampling for GPS data

### DIFF
--- a/gps_loading_files.R
+++ b/gps_loading_files.R
@@ -103,57 +103,33 @@ downsample_track <- function(track_dt, target_hz) {
 }
 
 prompt_target_frequency <- function(default_hz = 1) {
-  freq_values <- c("1 Hz" = 1, "5 Hz" = 5, "10 Hz" = 10)
-  default_label <- names(freq_values)[match(default_hz, freq_values)]
+  allowed_hz <- c(1, 5, 10)
 
   if (!interactive()) {
     message("ℹ️ Skript läuft nicht interaktiv – es wird standardmäßig ", default_hz, " Hz verwendet.")
     return(default_hz)
   }
 
-  if (rstudioapi::isAvailable() && rstudioapi::hasFun("selectList")) {
-    selection <- rstudioapi::selectList(
-      choices = names(freq_values),
-      title = "Wähle die maximale Ziel-Abtastrate für die Weiterverarbeitung",
-      selected = default_label,
-      multiple = FALSE
-    )
-
-    if (length(selection) == 0) {
-      message("ℹ️ Keine Auswahl getroffen – es wird standardmäßig ", default_hz, " Hz verwendet.")
-      return(default_hz)
-    }
-
-    chosen <- freq_values[[selection]]
-    message("ℹ️ Gewählte maximale Ziel-Abtastrate: ", chosen, " Hz.")
-    return(chosen)
-  }
-
-  old_menu_opt <- getOption("menu.graphics")
-  on.exit(options(menu.graphics = old_menu_opt), add = TRUE)
-  options(menu.graphics = FALSE)
+  prompt_text <- paste0(
+    "Wähle die maximale Ziel-Abtastrate (nur 1, 5 oder 10 Hz). ",
+    "Drücke Enter für den Standardwert ", default_hz, " Hz: "
+  )
 
   repeat {
-    selection <- utils::menu(
-      choices = names(freq_values),
-      title = paste0(
-        "Wähle die maximale Ziel-Abtastrate für die Weiterverarbeitung\n",
-        "(0 oder ESC für Abbruch – dann wird der Standardwert ", default_hz, " Hz genutzt)"
-      )
-    )
+    user_input <- readline(prompt_text)
 
-    if (selection <= 0) {
-      message("ℹ️ Keine Auswahl getroffen – es wird standardmäßig ", default_hz, " Hz verwendet.")
+    if (!nzchar(user_input)) {
+      message("ℹ️ Keine Eingabe – es wird standardmäßig ", default_hz, " Hz verwendet.")
       return(default_hz)
     }
 
-    chosen_hz <- unname(freq_values[selection])
-    if (is.finite(chosen_hz) && chosen_hz > 0) {
-      message("ℹ️ Gewählte maximale Ziel-Abtastrate: ", chosen_hz, " Hz.")
-      return(chosen_hz)
+    numeric_value <- suppressWarnings(as.numeric(user_input))
+    if (!is.na(numeric_value) && numeric_value %in% allowed_hz) {
+      message("ℹ️ Gewählte maximale Ziel-Abtastrate: ", numeric_value, " Hz.")
+      return(numeric_value)
     }
 
-    message("⚠️ Ungültige Auswahl. Bitte erneut versuchen.")
+    message("⚠️ Ungültige Eingabe. Erlaubt sind ausschließlich 1, 5 oder 10 Hz.")
   }
 }
 

--- a/gps_loading_files.R
+++ b/gps_loading_files.R
@@ -106,22 +106,60 @@ prompt_target_frequency <- function(default_hz = 1) {
     return(default_hz)
   }
 
-  if (rstudioapi::isAvailable() && rstudioapi::hasFun("selectList")) {
-    selection <- rstudioapi::selectList(
-      choices = names(freq_values),
-      title = "Wähle die maximale Ziel-Abtastrate für die Weiterverarbeitung",
-      selected = default_label,
-      multiple = FALSE
-    )
+  if (rstudioapi::isAvailable()) {
+    if (rstudioapi::hasFun("showPrompt")) {
+      numeric_options <- setNames(unname(freq_values), sub(" Hz$", "", names(freq_values)))
+      repeat {
+        selection <- rstudioapi::showPrompt(
+          title = "Maximale Ziel-Abtastrate",
+          message = paste(
+            "Bitte gewünschte maximale Ziel-Abtastrate auswählen (1, 5 oder 10 Hz).",
+            "Der Standardwert 1 Hz ist bereits vorbelegt."
+          ),
+          default = as.character(default_hz)
+        )
 
-    if (length(selection) == 0) {
-      message("ℹ️ Keine Auswahl getroffen – es wird standardmäßig ", default_hz, " Hz verwendet.")
-      return(default_hz)
+        if (is.null(selection)) {
+          message("ℹ️ Keine Auswahl getroffen – es wird standardmäßig ", default_hz, " Hz verwendet.")
+          return(default_hz)
+        }
+
+        selection <- trimws(selection)
+        selection_clean <- gsub("[^0-9]", "", selection)
+        if (selection_clean %in% names(numeric_options)) {
+          chosen <- numeric_options[[selection_clean]]
+          message("ℹ️ Gewählte maximale Ziel-Abtastrate: ", chosen, " Hz.")
+          return(chosen)
+        }
+
+        if (rstudioapi::hasFun("showDialog")) {
+          rstudioapi::showDialog(
+            title = "Ungültige Eingabe",
+            message = "Bitte geben Sie 1, 5 oder 10 ein."
+          )
+        } else {
+          message("⚠️ Ungültige Eingabe. Bitte 1, 5 oder 10 eingeben.")
+        }
+      }
     }
 
-    chosen <- freq_values[[selection]]
-    message("ℹ️ Gewählte maximale Ziel-Abtastrate: ", chosen, " Hz.")
-    return(chosen)
+    if (rstudioapi::hasFun("selectList")) {
+      selection <- rstudioapi::selectList(
+        choices = names(freq_values),
+        title = "Wähle die maximale Ziel-Abtastrate für die Weiterverarbeitung",
+        selected = default_label,
+        multiple = FALSE
+      )
+
+      if (length(selection) == 0) {
+        message("ℹ️ Keine Auswahl getroffen – es wird standardmäßig ", default_hz, " Hz verwendet.")
+        return(default_hz)
+      }
+
+      chosen <- freq_values[[selection]]
+      message("ℹ️ Gewählte maximale Ziel-Abtastrate: ", chosen, " Hz.")
+      return(chosen)
+    }
   }
 
   old_menu_opt <- getOption("menu.graphics")
@@ -257,25 +295,40 @@ empty_template <- data.table(
   time_offset_s = numeric()
 )
 
-resampled_list <- lapply(seq_along(gps_data), function(idx) {
+parsed_list <- vector("list", length(gps_data))
+resampled_list <- vector("list", length(gps_data))
+
+for (idx in seq_along(gps_data)) {
   key <- names(gps_data)[idx]
   lines <- gps_data[[idx]]
   parsed <- parse_rmc_lines(lines, tz_local)
-  if (is.null(parsed) || nrow(parsed) == 0) return(empty_template)
 
-  reduced <- downsample_track(parsed, target_hz)
-  if (nrow(reduced) == 0) return(empty_template)
+  if (!is.null(parsed) && nrow(parsed) > 0) {
+    parsed_with_id <- copy(parsed)
+    parsed_with_id[, track_id := as.integer(gsub("^track_", "", key))]
+    parsed_list[[idx]] <- parsed_with_id
 
-  reduced[, track_id := as.integer(gsub("^track_", "", key))]
-  reduced
-})
+    reduced <- downsample_track(parsed_with_id, target_hz)
+    if (!is.null(reduced) && nrow(reduced) > 0) {
+      resampled_list[[idx]] <- reduced
+    } else {
+      resampled_list[[idx]] <- empty_template
+    }
+  } else {
+    parsed_list[[idx]] <- empty_template
+    resampled_list[[idx]] <- empty_template
+  }
+}
 
+gps_points_raw <- rbindlist(parsed_list, fill = TRUE)
 gps_points_resampled <- rbindlist(resampled_list, fill = TRUE)
 
+assign("gps_points_raw", gps_points_raw, envir = .GlobalEnv)
 assign("gps_points_resampled", gps_points_resampled, envir = .GlobalEnv)
 assign("gps_resample_hz", target_hz, envir = .GlobalEnv)
 
 message(
   "✅ Reduzierter Datensatz mit ", target_hz, " Hz erstellt (",
-  nrow(gps_points_resampled), " Punkte) und in 'gps_points_resampled' abgelegt."
+  nrow(gps_points_resampled), " Punkte).",
+  " Vollständige Punkte befinden sich in 'gps_points_raw'."
 )

--- a/gps_loading_files.R
+++ b/gps_loading_files.R
@@ -106,6 +106,23 @@ if (!requireNamespace("rstudioapi", quietly = TRUE) || !rstudioapi::isAvailable(
 root <- rstudioapi::selectDirectory("Wähle Verzeichnis mit YYYY-MM Unterordnern oder direkt einen YYYY-MM-Ordner")
 if (is.null(root)) stop("Abbruch: Kein Ordner gewählt.")
 
+# ---- 1a. Maximale Ziel-Frequenz wählen ----
+freq_choices <- c("1 Hz" = "1", "5 Hz" = "5", "10 Hz" = "10")
+freq_selection <- utils::select.list(
+  choices = names(freq_choices),
+  title = "Wähle die maximale Ziel-Abtastrate für die Weiterverarbeitung",
+  multiple = FALSE,
+  preselect = "1 Hz"
+)
+
+if (length(freq_selection) == 0) {
+  target_hz <- 1
+  message("ℹ️ Keine Auswahl getroffen – es wird standardmäßig 1 Hz verwendet.")
+} else {
+  target_hz <- as.numeric(freq_choices[[freq_selection]])
+  message("ℹ️ Gewählte maximale Ziel-Abtastrate: ", target_hz, " Hz.")
+}
+
 # ---- 2. Regex für Ordner und Dateien ----
 tz_local <- Sys.timezone()
 re_dir <- "^[0-9]{4}-[0-9]{2}$"
@@ -187,23 +204,7 @@ assign("gps_data", gps_data, envir = .GlobalEnv)
 
 message("✅ Fertig. ", length(gps_data), " Dateien geladen aus ", length(ym_dirs), " Monatsordner(n).")
 
-# ---- 6. Frequenz für Weiterverarbeitung wählen ----
-freq_choices <- c("1 Hz" = "1", "5 Hz" = "5", "10 Hz" = "10")
-freq_selection <- utils::select.list(
-  choices = names(freq_choices),
-  title = "Wähle die Ziel-Abtastrate für die Weiterverarbeitung",
-  multiple = FALSE
-)
-
-if (length(freq_selection) == 0) {
-  target_hz <- 1
-  message("ℹ️ Keine Auswahl getroffen – es wird standardmäßig 1 Hz verwendet.")
-} else {
-  target_hz <- as.numeric(freq_choices[[freq_selection]])
-  message("ℹ️ Gewählte Ziel-Abtastrate: ", target_hz, " Hz.")
-}
-
-# ---- 7. Daten reduzieren und zusammenführen ----
+# ---- 6. Daten reduzieren und zusammenführen ----
 empty_template <- data.table(
   track_id = integer(),
   timestamp = as.POSIXct(character(), tz = tz_local),

--- a/gps_loading_files.R
+++ b/gps_loading_files.R
@@ -103,34 +103,49 @@ downsample_track <- function(track_dt, target_hz) {
 }
 
 prompt_target_frequency <- function(default_hz = 1) {
-  allowed_hz <- c(1, 5, 10)
+  freq_values <- c("1 Hz" = 1, "5 Hz" = 5, "10 Hz" = 10)
 
   if (!interactive()) {
     message("ℹ️ Skript läuft nicht interaktiv – es wird standardmäßig ", default_hz, " Hz verwendet.")
     return(default_hz)
   }
 
-  prompt_text <- paste0(
-    "Wähle die maximale Ziel-Abtastrate (nur 1, 5 oder 10 Hz). ",
-    "Drücke Enter für den Standardwert ", default_hz, " Hz: "
-  )
+  default_label <- names(freq_values)[match(default_hz, freq_values)]
 
-  repeat {
-    user_input <- readline(prompt_text)
+  if (!is.na(default_label) && rstudioapi::hasFun("selectList")) {
+    selection <- rstudioapi::selectList(
+      choices = names(freq_values),
+      title = "Wähle die maximale Ziel-Abtastrate für die Weiterverarbeitung",
+      selected = default_label,
+      multiple = FALSE
+    )
 
-    if (!nzchar(user_input)) {
-      message("ℹ️ Keine Eingabe – es wird standardmäßig ", default_hz, " Hz verwendet.")
+    if (length(selection) == 0) {
+      message("ℹ️ Keine Auswahl getroffen – es wird standardmäßig ", default_hz, " Hz verwendet.")
       return(default_hz)
     }
 
-    numeric_value <- suppressWarnings(as.numeric(user_input))
-    if (!is.na(numeric_value) && numeric_value %in% allowed_hz) {
-      message("ℹ️ Gewählte maximale Ziel-Abtastrate: ", numeric_value, " Hz.")
-      return(numeric_value)
-    }
-
-    message("⚠️ Ungültige Eingabe. Erlaubt sind ausschließlich 1, 5 oder 10 Hz.")
+    chosen <- freq_values[[selection]]
+    message("ℹ️ Gewählte maximale Ziel-Abtastrate: ", chosen, " Hz.")
+    return(chosen)
   }
+
+  # Fallback auf eine Konsolen-Auswahl, falls kein selectList verfügbar ist
+  selection <- utils::select.list(
+    choices = names(freq_values),
+    title = "Wähle die maximale Ziel-Abtastrate für die Weiterverarbeitung",
+    preselect = default_label,
+    multiple = FALSE
+  )
+
+  if (length(selection) == 0) {
+    message("ℹ️ Keine Auswahl getroffen – es wird standardmäßig ", default_hz, " Hz verwendet.")
+    return(default_hz)
+  }
+
+  chosen <- freq_values[[selection]]
+  message("ℹ️ Gewählte maximale Ziel-Abtastrate: ", chosen, " Hz.")
+  chosen
 }
 
 # Sicherstellen, dass rstudioapi verfügbar ist

--- a/gps_loading_files.R
+++ b/gps_loading_files.R
@@ -99,10 +99,29 @@ downsample_track <- function(track_dt, target_hz) {
 
 prompt_target_frequency <- function(default_hz = 1) {
   freq_values <- c("1 Hz" = 1, "5 Hz" = 5, "10 Hz" = 10)
+  default_label <- names(freq_values)[match(default_hz, freq_values)]
 
   if (!interactive()) {
     message("ℹ️ Skript läuft nicht interaktiv – es wird standardmäßig ", default_hz, " Hz verwendet.")
     return(default_hz)
+  }
+
+  if (rstudioapi::isAvailable() && rstudioapi::hasFun("selectList")) {
+    selection <- rstudioapi::selectList(
+      choices = names(freq_values),
+      title = "Wähle die maximale Ziel-Abtastrate für die Weiterverarbeitung",
+      selected = default_label,
+      multiple = FALSE
+    )
+
+    if (length(selection) == 0) {
+      message("ℹ️ Keine Auswahl getroffen – es wird standardmäßig ", default_hz, " Hz verwendet.")
+      return(default_hz)
+    }
+
+    chosen <- freq_values[[selection]]
+    message("ℹ️ Gewählte maximale Ziel-Abtastrate: ", chosen, " Hz.")
+    return(chosen)
   }
 
   old_menu_opt <- getOption("menu.graphics")


### PR DESCRIPTION
## Summary
- add helper utilities to parse NMEA RMC data and convert coordinates with timestamps
- prompt for a target sampling rate and build a reduced GPS point dataset at 1, 5, or 10 Hz
- expose the resampled data frame and selected frequency for downstream processing

## Testing
- not run (interactive R script)

------
https://chatgpt.com/codex/tasks/task_e_68dbb56c53848330901b37f8dbab258d